### PR TITLE
Add default -d = dir of torrent to btcli add

### DIFF
--- a/cli/add.c
+++ b/cli/add.c
@@ -6,7 +6,7 @@ usage_add(void)
     printf(
         "Add torrents to btpd.\n"
         "\n"
-        "Usage: add [-n name] [-T] [-N] -d dir file(s)\n"
+        "Usage: add [-n name] [-T] [-N] [-d dir] file(s)\n"
         "\n"
         "Arguments:\n"
         "file\n"
@@ -74,7 +74,7 @@ cmd_add(int argc, char **argv)
     argc -= optind;
     argv += optind;
 
-    if (argc < 1 || dir == NULL)
+    if (argc < 1)
         usage_add();
 
     btpd_connect();
@@ -88,6 +88,13 @@ cmd_add(int argc, char **argv)
        if ((mi = mi_load(argv[nfile], &mi_size)) == NULL) {
            fprintf(stderr, "error loading '%s' (%s).\n", argv[nfile], strerror(errno));
            continue;
+       }
+       if (dir == NULL) {
+           dir = dirname(argv[nfile]);
+           if ((dirlen = strlen(dir)) == 0) {
+                fprintf(stderr, "error obtaining dirname for '%s'.\n", argv[nfile]);
+                continue;
+           }
        }
        iob = iobuf_init(PATH_MAX);
        iobuf_write(&iob, dir, dirlen);

--- a/cli/btcli.h
+++ b/cli/btcli.h
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <inttypes.h>
+#include <libgen.h>
 #include <limits.h>
 #include <math.h>
 #include <stdio.h>


### PR DESCRIPTION
This very minor change makes the -d dir flag optional for `btcli add', defaulting to the directory the torrent is located in, or "." if no directory can be found for the torrent. 

Uses dirname() from libgen.h.

I use this in conjunction with -T to emulate the default behaviour of most other torrent clients, such as rtorrent.
