### PR TITLE
add instructions for git build to README

### DIFF
--- a/README
+++ b/README
@@ -18,6 +18,7 @@ Contents
 3               Building
 3.a               Requirements
 3.b               Standard build
+3.c               Git build
 4               Additional notes
 4.a               Upgrade form old versions
 4.b               Pre exit mode
@@ -182,6 +183,8 @@ Contents
   * OpenSSL   - Get at <URL:http://www.openssl.org/>
 
   You also need a c99 compiler. A non antique GCC should do.
+  
+  If building from git, you will also need autoconf and automake.
 
 3.b Standard build
 
@@ -190,6 +193,16 @@ Contents
   # make install
 
   See './configure --help' for available build options if the above fails.
+  
+3.c Git build
+
+  Building from git requires a few extra steps to generate the configure scripts first:
+  
+  # aclocal
+  # autoconf
+  # automake -ac
+  
+  You should now have the configure script generated and can follow the steps above for building from source tarballs.
 
 4. Additional notes
 


### PR DESCRIPTION
Mostly copied text from https://github.com/btpd/btpd/wiki/Building-btpd into README. Added section 3.c for git instructions and extra note in 3.a (Requirements) about autoconf and automake. This makes building less confusing for people who look to README in their cloned repo for build instructions and find that they don't work.
