### PR TITLE
Check non-standard `.utf-8'-suffixed fields first

### DIFF
--- a/misc/metainfo.c
+++ b/misc/metainfo.c
@@ -235,7 +235,10 @@ mi_files(const char *p)
             return NULL;
         for (fdct = benc_first(files); fdct != NULL; fdct = benc_next(fdct)) {
             fi[i].length = benc_dget_int(fdct, "length");
-            fi[i].path = mi_filepath(benc_dget_lst(fdct, "path"));
+            if (benc_dget_lst(fdct, "path.utf-8") != NULL)
+                fi[i].path = mi_filepath(benc_dget_lst(fdct, "path.utf-8"));
+            else
+                fi[i].path = mi_filepath(benc_dget_lst(fdct, "path"));
             if (fi[i].path == NULL) {
                 mi_free_files(nfiles, fi);
                 return NULL;
@@ -246,7 +249,9 @@ mi_files(const char *p)
         if ((fi = calloc(1, sizeof(*fi))) == NULL)
             return NULL;
         fi[0].length = benc_dget_int(info, "length");
-        fi[0].path = benc_dget_str(info, "name", NULL);
+        fi[0].path = benc_dget_str(info, "name.utf-8", NULL);
+        if (fi[0].path == NULL)
+            fi[0].path = benc_dget_str(info, "name", NULL);
         if (fi[0].path == NULL) {
             free(fi);
             return NULL;


### PR DESCRIPTION
While the official specification requires all strings to be UTF-8 encoded, not all files are compliant. Most of them seem to provide alternative UTF-8 fields, which weren't used by btpd.