### PR TITLE
use in-source sha1 implementation: libcrypto no longer required

### DIFF
--- a/btpd/btpd.c
+++ b/btpd/btpd.c
@@ -1,6 +1,5 @@
 #include "btpd.h"
 
-#include <openssl/sha.h>
 #include <signal.h>
 
 static uint8_t m_peer_id[20];
@@ -114,7 +113,7 @@ btpd_init(void)
     idcon[sizeof(idcon) - 1] = '\0';
     n = strlen(idcon);
 
-    SHA1(idcon, n, m_peer_id);
+    quicksha1(idcon, n, m_peer_id);
     bcopy(m_peer_id, &seed, sizeof(seed));
     bcopy(BTPD_VERSION, m_peer_id, sizeof(BTPD_VERSION) - 1);
     m_peer_id[sizeof(BTPD_VERSION) - 1] = '|';

--- a/btpd/btpd.h
+++ b/btpd/btpd.h
@@ -48,6 +48,7 @@
 #include "content.h"
 #include "opts.h"
 #include "tracker_req.h"
+#include "sha1.h"
 
 #define BTPD_VERSION PACKAGE_NAME "/" PACKAGE_VERSION
 

--- a/btpd/download_subr.c
+++ b/btpd/download_subr.c
@@ -21,7 +21,6 @@
 
 #include "btpd.h"
 
-#include <openssl/sha.h>
 #include <stream.h>
 
 static void
@@ -42,7 +41,7 @@ piece_log_hashes(struct piece *pc)
     for (unsigned i = 0; i < pc->nblocks; i++) {
         uint32_t bsize = torrent_block_size(tp, pc->index, pc->nblocks, i);
         cm_get_bytes(tp, pc->index, i * PIECE_BLOCKLEN, bsize, &buf);
-        SHA1(buf, bsize, &log->hashes[i * 20]);
+        quicksha1(buf, bsize, &log->hashes[i * 20]);
         free(buf);
     }
 }

--- a/btpd/torrent.c
+++ b/btpd/torrent.c
@@ -1,7 +1,5 @@
 #include "btpd.h"
 
-#include <openssl/sha.h>
-
 #define SAVE_INTERVAL 300
 
 static unsigned m_nghosts;

--- a/config.mk
+++ b/config.mk
@@ -11,7 +11,7 @@ EVLOOP = ./evloop
 
 # includes and libs
 INCS = -I${MISC} -I${EVLOOP}
-LIBS = -lcrypto -lm -lpthread
+LIBS = -lm -lpthread
 
 # flags
 CPPFLAGS = ${INCS} -DHAVE_CLOCK_MONOTONIC=1 -DEVLOOP_POLL

--- a/config.mk.def
+++ b/config.mk.def
@@ -11,7 +11,7 @@ EVLOOP = ./evloop
 
 # includes and libs
 INCS = -I${MISC} -I${EVLOOP}
-LIBS = -lcrypto -lm -lpthread
+LIBS = -lm -lpthread
 
 # flags
 CPPFLAGS = ${INCS} -DHAVE_CLOCK_MONOTONIC=1 -DEVLOOP_NONE

--- a/misc/metainfo.c
+++ b/misc/metainfo.c
@@ -6,11 +6,10 @@
 #include <string.h>
 #include <strings.h>
 
-#include <openssl/sha.h>
-
 #include "benc.h"
 #include "metainfo.h"
 #include "subr.h"
+#include "sha1.h"
 
 /*
  * d
@@ -159,7 +158,7 @@ mi_info_hash(const char *p, uint8_t *hash)
     if (hash == NULL)
         if ((hash = malloc(20)) == NULL)
             return NULL;
-    return SHA1(info, benc_length(info), hash);
+    return quicksha1(info, benc_length(info), hash);
 }
 
 char *

--- a/misc/sha1.c
+++ b/misc/sha1.c
@@ -1,0 +1,159 @@
+/* public domain sha1 implementation based on rfc3174 and libtomcrypt */
+#include <stdint.h>
+#include <string.h>
+
+#include "sha1.h"
+
+static uint32_t rol(uint32_t n, int k) { return (n << k) | (n >> (32-k)); }
+#define F0(b,c,d) (d ^ (b & (c ^ d)))
+#define F1(b,c,d) (b ^ c ^ d)
+#define F2(b,c,d) ((b & c) | (d & (b | c)))
+#define F3(b,c,d) (b ^ c ^ d)
+#define G0(a,b,c,d,e,i) e += rol(a,5)+F0(b,c,d)+W[i]+0x5A827999; b = rol(b,30)
+#define G1(a,b,c,d,e,i) e += rol(a,5)+F1(b,c,d)+W[i]+0x6ED9EBA1; b = rol(b,30)
+#define G2(a,b,c,d,e,i) e += rol(a,5)+F2(b,c,d)+W[i]+0x8F1BBCDC; b = rol(b,30)
+#define G3(a,b,c,d,e,i) e += rol(a,5)+F3(b,c,d)+W[i]+0xCA62C1D6; b = rol(b,30)
+
+static void
+processblock(struct sha1 *s, const uint8_t *buf)
+{
+	uint32_t W[80], a, b, c, d, e;
+	int i;
+
+	for (i = 0; i < 16; i++) {
+		W[i] = (uint32_t)buf[4*i]<<24;
+		W[i] |= (uint32_t)buf[4*i+1]<<16;
+		W[i] |= (uint32_t)buf[4*i+2]<<8;
+		W[i] |= buf[4*i+3];
+	}
+	for (; i < 80; i++)
+		W[i] = rol(W[i-3] ^ W[i-8] ^ W[i-14] ^ W[i-16], 1);
+	a = s->h[0];
+	b = s->h[1];
+	c = s->h[2];
+	d = s->h[3];
+	e = s->h[4];
+	for (i = 0; i < 20; ) {
+		G0(a,b,c,d,e,i++);
+		G0(e,a,b,c,d,i++);
+		G0(d,e,a,b,c,i++);
+		G0(c,d,e,a,b,i++);
+		G0(b,c,d,e,a,i++);
+	}
+	while (i < 40) {
+		G1(a,b,c,d,e,i++);
+		G1(e,a,b,c,d,i++);
+		G1(d,e,a,b,c,i++);
+		G1(c,d,e,a,b,i++);
+		G1(b,c,d,e,a,i++);
+	}
+	while (i < 60) {
+		G2(a,b,c,d,e,i++);
+		G2(e,a,b,c,d,i++);
+		G2(d,e,a,b,c,i++);
+		G2(c,d,e,a,b,i++);
+		G2(b,c,d,e,a,i++);
+	}
+	while (i < 80) {
+		G3(a,b,c,d,e,i++);
+		G3(e,a,b,c,d,i++);
+		G3(d,e,a,b,c,i++);
+		G3(c,d,e,a,b,i++);
+		G3(b,c,d,e,a,i++);
+	}
+	s->h[0] += a;
+	s->h[1] += b;
+	s->h[2] += c;
+	s->h[3] += d;
+	s->h[4] += e;
+}
+
+static void
+pad(struct sha1 *s)
+{
+	unsigned r = s->len % 64;
+
+	s->buf[r++] = 0x80;
+	if (r > 56) {
+		memset(s->buf + r, 0, 64 - r);
+		r = 0;
+		processblock(s, s->buf);
+	}
+	memset(s->buf + r, 0, 56 - r);
+	s->len *= 8;
+	s->buf[56] = s->len >> 56;
+	s->buf[57] = s->len >> 48;
+	s->buf[58] = s->len >> 40;
+	s->buf[59] = s->len >> 32;
+	s->buf[60] = s->len >> 24;
+	s->buf[61] = s->len >> 16;
+	s->buf[62] = s->len >> 8;
+	s->buf[63] = s->len;
+	processblock(s, s->buf);
+}
+
+void
+sha1_init(void *ctx)
+{
+	struct sha1 *s = ctx;
+
+	s->len = 0;
+	s->h[0] = 0x67452301;
+	s->h[1] = 0xEFCDAB89;
+	s->h[2] = 0x98BADCFE;
+	s->h[3] = 0x10325476;
+	s->h[4] = 0xC3D2E1F0;
+}
+
+void
+sha1_sum(void *ctx, uint8_t md[SHA1_DIGEST_LENGTH])
+{
+	struct sha1 *s = ctx;
+	int i;
+
+	pad(s);
+	for (i = 0; i < 5; i++) {
+		md[4*i] = s->h[i] >> 24;
+		md[4*i+1] = s->h[i] >> 16;
+		md[4*i+2] = s->h[i] >> 8;
+		md[4*i+3] = s->h[i];
+	}
+}
+
+void
+sha1_update(void *ctx, const void *m, unsigned long len)
+{
+	struct sha1 *s = ctx;
+	const uint8_t *p = m;
+	unsigned r = s->len % 64;
+
+	s->len += len;
+	if (r) {
+		if (len < 64 - r) {
+			memcpy(s->buf + r, p, len);
+			return;
+		}
+		memcpy(s->buf + r, p, 64 - r);
+		len -= 64 - r;
+		p += 64 - r;
+		processblock(s, s->buf);
+	}
+	for (; len >= 64; len -= 64, p += 64)
+		processblock(s, p);
+	memcpy(s->buf, p, len);
+}
+
+uint8_t *
+quicksha1(const void *m, unsigned long len, uint8_t md[SHA1_DIGEST_LENGTH])
+{
+    struct sha1 ctx;
+
+    if (m == NULL || md == NULL)
+        return NULL;
+
+    sha1_init(&ctx);
+    sha1_update(&ctx, m, len);
+    sha1_sum(&ctx, md);
+
+    return md;
+}

--- a/misc/sha1.h
+++ b/misc/sha1.h
@@ -1,0 +1,20 @@
+/* public domain sha1 implementation based on rfc3174 and libtomcrypt */
+
+struct sha1 {
+	uint64_t len;    /* processed message length */
+	uint32_t h[5];   /* hash state */
+	uint8_t buf[64]; /* message block buffer */
+};
+
+enum { SHA1_DIGEST_LENGTH = 20 };
+
+/* reset state */
+void sha1_init(void *ctx);
+/* process message */
+void sha1_update(void *ctx, const void *m, unsigned long len);
+/* get message digest */
+/* state is ruined after sum, keep a copy if multiple sum is needed */
+/* part of the message might be left in s, zero it if secrecy is needed */
+void sha1_sum(void *ctx, uint8_t md[SHA1_DIGEST_LENGTH]);
+/* single-call version */
+uint8_t *quicksha1(const void *m, unsigned long len, uint8_t md[SHA1_DIGEST_LENGTH]);

--- a/misc/stream.c
+++ b/misc/stream.c
@@ -5,8 +5,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <openssl/sha.h>
-
+#include "sha1.h"
 #include "metainfo.h"
 #include "subr.h"
 #include "stream.h"
@@ -161,21 +160,21 @@ bts_put(struct bt_stream *bts, off_t off, const uint8_t *buf, size_t len)
 int
 bts_sha(struct bt_stream *bts, off_t start, off_t length, uint8_t *hash)
 {
-    SHA_CTX ctx;
+    struct sha1 ctx;
     char buf[SHAFILEBUF];
     size_t wantread;
     int err = 0;
 
-    SHA1_Init(&ctx);
+    sha1_init(&ctx);
     while (length > 0) {
         wantread = min(length, SHAFILEBUF);
         if ((err = bts_get(bts, start, buf, wantread)) != 0)
             break;
         length -= wantread;
         start += wantread;
-        SHA1_Update(&ctx, buf, wantread);
+        sha1_update(&ctx, buf, wantread);
     }
-    SHA1_Final(hash, &ctx);
+    sha1_sum(&ctx, hash);
     return err;
 }
 


### PR DESCRIPTION
The only thing btpd uses openssl/libressl libcrypto for is its SHA1 implementation. There are plenty of high quality SHA1 implementations outside of libcrypto, so I replaced it with one used in [sbase](https://core.suckless.org/sbase/), which is public domain.

Given how simple the usage is, it does not seem necessary for a program that does not use SSL to be dependent on an SSL library.